### PR TITLE
update: dependabotの更新方法を設定した

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,7 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 10
+    strategy:
+      versioning-strategy: 'lockfile-only'
     reviewers:
       - 'ryo-manba'


### PR DESCRIPTION
現状の設定では、`package.json`のみが変更されているためbuildが通らない。
そこで、`pnpm.lock.yml`も更新させる用に設定を変更した。

参考
https://docs.github.com/ja/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy