### PR TITLE
fix: dynamic revalidate settings

### DIFF
--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -3,7 +3,7 @@ import { PageTitle } from '@/components/PageTitle';
 import { BlogList } from '@/app/posts/components/BlogList';
 import { fetchRssFeeds } from '@/app/posts/api/fetchRssFeeds';
 
-export const revalidate = 60 * 60 * 24; // revalidate this page every　1 day
+export const revalidate = 86400; // revalidate this page every　1 day
 
 const pageTitle = 'Posts';
 const title = 'ブログ記事一覧 - ryo-manba';


### PR DESCRIPTION
revalidateの設定で計算式が使用できなかった

> The values of the config options currently need be statically analyzable. For example revalidate = 600 is valid, but revalidate = 60 * 10 is not.

https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#revalidate