### PR TITLE
fix: exclude code block headings from table of contents

### DIFF
--- a/src/app/blog/utils/extractHeadings.ts
+++ b/src/app/blog/utils/extractHeadings.ts
@@ -7,11 +7,12 @@ export type TocItem = {
 };
 
 export function extractHeadings(content: string): TocItem[] {
+  const contentWithoutCodeBlocks = content.replace(/```[\s\S]*?```/g, "");
   const headingRegex = /^(#{2,4})\s+(.+)$/gm;
   const headings: TocItem[] = [];
   const slugger = new GithubSlugger();
 
-  for (const match of Array.from(content.matchAll(headingRegex))) {
+  for (const match of Array.from(contentWithoutCodeBlocks.matchAll(headingRegex))) {
     const level = match[1].length;
     const text = match[2].trim();
     const id = slugger.slug(text);


### PR DESCRIPTION
## Summary
- Strip fenced code blocks from markdown content before extracting headings for the TOC
- Prevents lines like `## heading` inside code blocks from appearing in the table of contents

## Test plan
- [ ] Verify TOC no longer includes headings from code blocks (e.g. `gh-trend-reporter-agent-design` post)
- [ ] Verify TOC still correctly includes all real headings
- [ ] Verify TOC anchor links still scroll to the correct sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)