### PR TITLE
fix: tighten image upload checks on WebNN demo

### DIFF
--- a/src/app/labs/webnn/page.tsx
+++ b/src/app/labs/webnn/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import Script from "next/script";
 import { PageTitle } from "@/components/PageTitle";
+import { validateImageFile, type ImageValidationError } from "./validateImage";
 
 const ORT_CDN = "https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/ort.min.js";
 const MODEL_URL =
@@ -93,8 +94,30 @@ export default function WebNNDemo() {
     }
   }, []);
 
-  const handleFile = (file: File) => {
-    if (!file.type.startsWith("image/")) return;
+  // Object URL クリーンアップ（メモリリーク対策）
+  useEffect(() => {
+    return () => {
+      if (imageUrl) {
+        URL.revokeObjectURL(imageUrl);
+      }
+    };
+  }, [imageUrl]);
+
+  const handleFile = async (file: File) => {
+    const result = await validateImageFile(file);
+    if (!result.ok) {
+      const messages: Record<ImageValidationError, string> = {
+        "too-large": "画像ファイルは 10MB 以下にしてください",
+        "unsupported-mime": "JPEG/PNG/WebP/GIF のみサポートしています",
+        "magic-byte-mismatch": "ファイルの中身が画像形式と一致しません",
+      };
+      setStatus(messages[result.error]);
+      setResults([]);
+      return;
+    }
+    if (imageUrl) {
+      URL.revokeObjectURL(imageUrl);
+    }
     const url = URL.createObjectURL(file);
     setImageUrl(url);
     setResults([]);
@@ -301,7 +324,7 @@ export default function WebNNDemo() {
               e.preventDefault();
               e.stopPropagation();
               const file = e.dataTransfer.files[0];
-              if (file) handleFile(file);
+              if (file) void handleFile(file);
             }}
             onClick={() => fileInputRef.current?.click()}
             style={{
@@ -325,11 +348,11 @@ export default function WebNNDemo() {
           <input
             ref={fileInputRef}
             type="file"
-            accept="image/*"
+            accept="image/jpeg,image/png,image/webp,image/gif"
             style={{ display: "none" }}
             onChange={(e) => {
               const file = e.target.files?.[0];
-              if (file) handleFile(file);
+              if (file) void handleFile(file);
             }}
           />
           <canvas ref={canvasRef} style={{ display: "none" }} />

--- a/src/app/labs/webnn/validateImage.test.ts
+++ b/src/app/labs/webnn/validateImage.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { IMAGE_VALIDATION_LIMITS, validateImageFile } from "./validateImage";
+
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const JPEG_MAGIC = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01];
+const GIF_MAGIC = [0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00];
+// "RIFF" + 4 bytes file size + "WEBP"
+const WEBP_MAGIC = [0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50];
+
+function makeFile(bytes: number[], name: string, type: string): File {
+  return new File([new Uint8Array(bytes)], name, { type });
+}
+
+describe("validateImageFile", () => {
+  it("accepts a valid PNG", async () => {
+    const file = makeFile(PNG_MAGIC, "test.png", "image/png");
+    const result = await validateImageFile(file);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("accepts a valid JPEG", async () => {
+    const file = makeFile(JPEG_MAGIC, "test.jpg", "image/jpeg");
+    const result = await validateImageFile(file);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("accepts a valid GIF", async () => {
+    const file = makeFile(GIF_MAGIC, "test.gif", "image/gif");
+    const result = await validateImageFile(file);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("accepts a valid WebP", async () => {
+    const file = makeFile(WEBP_MAGIC, "test.webp", "image/webp");
+    const result = await validateImageFile(file);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects SVG with text/xml as unsupported MIME", async () => {
+    const svgBytes = Array.from(new TextEncoder().encode("<svg xmlns='...'></svg>"));
+    const file = makeFile(svgBytes, "evil.svg", "text/xml");
+    const result = await validateImageFile(file);
+    expect(result).toEqual({ ok: false, error: "unsupported-mime" });
+  });
+
+  it("rejects image/svg+xml as unsupported MIME", async () => {
+    const svgBytes = Array.from(new TextEncoder().encode("<svg xmlns='...'></svg>"));
+    const file = makeFile(svgBytes, "evil.svg", "image/svg+xml");
+    const result = await validateImageFile(file);
+    expect(result).toEqual({ ok: false, error: "unsupported-mime" });
+  });
+
+  it("rejects PNG MIME but plain text body as magic-byte-mismatch", async () => {
+    const textBytes = Array.from(new TextEncoder().encode("not a real png file body"));
+    const file = makeFile(textBytes, "fake.png", "image/png");
+    const result = await validateImageFile(file);
+    expect(result).toEqual({ ok: false, error: "magic-byte-mismatch" });
+  });
+
+  it("rejects files larger than 10MB as too-large", async () => {
+    const oversize = IMAGE_VALIDATION_LIMITS.maxFileSize + 1;
+    // Build a sparse file efficiently: just allocate one big Uint8Array
+    const big = new Uint8Array(oversize);
+    big[0] = 0x89;
+    big[1] = 0x50;
+    big[2] = 0x4e;
+    big[3] = 0x47;
+    const file = new File([big], "big.png", { type: "image/png" });
+    const result = await validateImageFile(file);
+    expect(result).toEqual({ ok: false, error: "too-large" });
+  });
+
+  it("rejects application/octet-stream as unsupported MIME", async () => {
+    const file = makeFile(PNG_MAGIC, "blob.bin", "application/octet-stream");
+    const result = await validateImageFile(file);
+    expect(result).toEqual({ ok: false, error: "unsupported-mime" });
+  });
+});

--- a/src/app/labs/webnn/validateImage.ts
+++ b/src/app/labs/webnn/validateImage.ts
@@ -1,0 +1,68 @@
+const ALLOWED_MIME_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "image/gif"]);
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+export type ImageValidationError = "too-large" | "unsupported-mime" | "magic-byte-mismatch";
+
+export type ImageValidationResult = { ok: true } | { ok: false; error: ImageValidationError };
+
+export async function validateImageFile(file: File): Promise<ImageValidationResult> {
+  if (file.size > MAX_FILE_SIZE) {
+    return { ok: false, error: "too-large" };
+  }
+  if (!ALLOWED_MIME_TYPES.has(file.type)) {
+    return { ok: false, error: "unsupported-mime" };
+  }
+  // マジックバイトを読んで MIME と整合するか確認
+  const header = await readFirstBytes(file, 12);
+  if (!matchesMagicBytes(header, file.type)) {
+    return { ok: false, error: "magic-byte-mismatch" };
+  }
+  return { ok: true };
+}
+
+async function readFirstBytes(file: File, n: number): Promise<Uint8Array> {
+  const slice = file.slice(0, n);
+  const buf = await slice.arrayBuffer();
+  return new Uint8Array(buf);
+}
+
+function matchesMagicBytes(header: Uint8Array, mime: string): boolean {
+  switch (mime) {
+    case "image/jpeg":
+      return header[0] === 0xff && header[1] === 0xd8 && header[2] === 0xff;
+    case "image/png":
+      return (
+        header[0] === 0x89 &&
+        header[1] === 0x50 &&
+        header[2] === 0x4e &&
+        header[3] === 0x47 &&
+        header[4] === 0x0d &&
+        header[5] === 0x0a &&
+        header[6] === 0x1a &&
+        header[7] === 0x0a
+      );
+    case "image/gif":
+      // "GIF8" — covers GIF87a and GIF89a
+      return header[0] === 0x47 && header[1] === 0x49 && header[2] === 0x46 && header[3] === 0x38;
+    case "image/webp":
+      // RIFF....WEBP
+      return (
+        header[0] === 0x52 &&
+        header[1] === 0x49 &&
+        header[2] === 0x46 &&
+        header[3] === 0x46 &&
+        header[8] === 0x57 &&
+        header[9] === 0x45 &&
+        header[10] === 0x42 &&
+        header[11] === 0x50
+      );
+    default:
+      return false;
+  }
+}
+
+export const IMAGE_VALIDATION_LIMITS = {
+  maxFileSize: MAX_FILE_SIZE,
+  allowedMimeTypes: Array.from(ALLOWED_MIME_TYPES),
+};


### PR DESCRIPTION
Internal hardening for client-side image input on the WebNN demo. Adds unit tests.