### PR TITLE
feat: ブログ記事に BlogPosting の JSON-LD 構造化データを追加

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { Breadcrumb } from "../components/Breadcrumb";
 import { CopyMarkdownButton } from "../components/CopyMarkdownButton";
 import { LikeButton } from "../components/LikeButton";
 import { TableOfContents } from "../components/TableOfContents";
+import { buildBlogPostingJsonLd } from "../utils/buildBlogPostingJsonLd";
 import { extractHeadings } from "../utils/extractHeadings";
 import { getBlogPost, getBlogPosts } from "../utils/getBlogPosts";
 import { calculateReadingTime, formatReadingTime } from "../utils/readingTime";
@@ -163,6 +164,9 @@ export default async function BlogPost({ params }: Props) {
 
   const breadcrumbItems = [{ label: "Home", href: "/" }, { label: "Blog", href: "/blog" }, { label: post.title }];
 
+  // 検索エンジンのリッチリザルト向けに BlogPosting 構造化データを埋め込む
+  const jsonLd = buildBlogPostingJsonLd(post);
+
   const headerContent = (
     <>
       <Breadcrumb items={breadcrumbItems} />
@@ -206,6 +210,8 @@ export default async function BlogPost({ params }: Props) {
 
   return (
     <div className="min-h-screen">
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD はサーバー側の信頼できるデータを JSON.stringify でエスケープして埋め込むため安全 */}
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <div className="max-w-7xl mx-auto px-4 pt-4 pb-8 flex justify-center gap-5">
         <BlogPostLayout content={post.content} lang={post.lang || "en"} header={headerContent}>
           <MDXRemote

--- a/src/app/blog/utils/buildBlogPostingJsonLd.ts
+++ b/src/app/blog/utils/buildBlogPostingJsonLd.ts
@@ -1,0 +1,42 @@
+import { BlogPost } from "../types";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+
+const AUTHOR_NAME = "Ryo Matsukawa";
+const PUBLISHER_NAME = "ryo-manba";
+
+/**
+ * Build a schema.org BlogPosting JSON-LD object for a blog post.
+ * リッチリザルト向けの構造化データを生成する。
+ * @param post - 対象のブログ記事
+ * @returns JSON-LD として埋め込める BlogPosting オブジェクト
+ */
+export function buildBlogPostingJsonLd(post: BlogPost): Record<string, unknown> {
+  const postUrl = `${SITE_URL}/blog/${post.slug}`;
+  // OG 画像は専用ルートで動的生成する（別ブランチで追加）。絶対 URL で参照する。
+  const imageUrl = `${SITE_URL}/blog/${post.slug}/opengraph-image`;
+  const publishedDate = new Date(post.date).toISOString();
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    description: post.description,
+    datePublished: publishedDate,
+    // 更新日時の情報がないため公開日時と同じ値を使う
+    dateModified: publishedDate,
+    author: {
+      "@type": "Person",
+      name: AUTHOR_NAME,
+    },
+    publisher: {
+      "@type": "Person",
+      name: PUBLISHER_NAME,
+    },
+    image: imageUrl,
+    keywords: post.tags ?? [],
+    url: postUrl,
+    mainEntityOfPage: postUrl,
+    inLanguage: post.lang || "ja",
+  };
+}


### PR DESCRIPTION
## 概要
検索エンジンのリッチリザルト表示に対応するため、ブログ記事ページに schema.org の `BlogPosting` 構造化データ（JSON-LD）を追加しました。

## 変更点
- `src/app/blog/utils/buildBlogPostingJsonLd.ts` を新規追加
  - 記事情報から `headline` / `description` / `datePublished` / `dateModified` / `author` / `publisher` / `image` / `keywords` / `url` / `mainEntityOfPage` / `inLanguage` を生成
  - `image` は動的 OG 画像ルート `${NEXT_PUBLIC_SITE_URL}/blog/<slug>/opengraph-image` の絶対 URL を参照
  - `inLanguage` は `post.lang`（未指定時は `ja`）
- `src/app/blog/[slug]/page.tsx` で上記ユーティリティを呼び出し、`<script type="application/ld+json">` として出力
  - `JSON.stringify` でエスケープして埋め込み（XSS の懸念なし）

## 動作確認
- `npx tsc --noEmit` → エラーなし
- `npx biome check`（変更ファイル）→ エラーなし
- `PORT=3102 npm run dev` で起動し、`/blog/20260527-postgres-explain-analyze-scan-strategies` を取得
  - `application/ld+json` ブロックを抽出し `JSON.parse` が成功、`@type: "BlogPosting"` および全必須フィールドが正しく出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)