### PR TITLE
feat: ブログのRSSフィードを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,5 @@ jobs:
         run: pnpm run lint
       - name: Run Build
         run: pnpm run build
+        env:
+          NEXT_PUBLIC_SITE_URL: https://ryo-manba.vercel.app

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -3,10 +3,15 @@ import { getBlogPosts } from "@/app/blog/utils/getBlogPosts";
 // ブログページと同様に 1 時間ごとに再生成する
 export const revalidate = 3600;
 
+function requireEnv(key: string): string {
+  const value = process.env[key];
+  if (!value) throw new Error(`${key} is not set`);
+  return value;
+}
+
 const SITE_NAME = "ryo-manba";
 const SITE_DESCRIPTION = "Ryo Matsukawa のブログ記事の RSS フィードです。";
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL;
-if (!SITE_URL) throw new Error("NEXT_PUBLIC_SITE_URL is not set");
+const SITE_URL = requireEnv("NEXT_PUBLIC_SITE_URL");
 
 // XML 内で特殊な意味を持つ文字をエスケープする
 function escapeXml(value: string): string {

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -5,7 +5,8 @@ export const revalidate = 3600;
 
 const SITE_NAME = "ryo-manba";
 const SITE_DESCRIPTION = "Ryo Matsukawa のブログ記事の RSS フィードです。";
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL;
+if (!SITE_URL) throw new Error("NEXT_PUBLIC_SITE_URL is not set");
 
 // XML 内で特殊な意味を持つ文字をエスケープする
 function escapeXml(value: string): string {

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,63 @@
+import { getBlogPosts } from "@/app/blog/utils/getBlogPosts";
+
+// ブログページと同様に 1 時間ごとに再生成する
+export const revalidate = 3600;
+
+const SITE_NAME = "ryo-manba";
+const SITE_DESCRIPTION = "Ryo Matsukawa のブログ記事の RSS フィードです。";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000";
+
+// XML 内で特殊な意味を持つ文字をエスケープする
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export async function GET() {
+  const posts = getBlogPosts();
+
+  // 最新記事の日付を lastBuildDate に利用する（記事が無い場合は現在時刻）
+  const lastBuildDate = posts.length > 0 ? new Date(posts[0].date) : new Date();
+
+  const items = posts
+    .map((post) => {
+      const postUrl = `${SITE_URL}/blog/${post.slug}`;
+      const categories = (post.tags ?? []).map((tag) => `      <category>${escapeXml(tag)}</category>`).join("\n");
+
+      return [
+        "    <item>",
+        `      <title>${escapeXml(post.title)}</title>`,
+        `      <link>${escapeXml(postUrl)}</link>`,
+        `      <guid isPermaLink="true">${escapeXml(postUrl)}</guid>`,
+        `      <description>${escapeXml(post.description)}</description>`,
+        `      <pubDate>${new Date(post.date).toUTCString()}</pubDate>`,
+        categories,
+        "    </item>",
+      ]
+        .filter((line) => line.length > 0)
+        .join("\n");
+    })
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>${escapeXml(SITE_NAME)}</title>
+    <link>${escapeXml(SITE_URL)}</link>
+    <description>${escapeXml(SITE_DESCRIPTION)}</description>
+    <language>ja</language>
+    <lastBuildDate>${lastBuildDate.toUTCString()}</lastBuildDate>
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+    },
+  });
+}


### PR DESCRIPTION
## 概要
ブログ記事の RSS 2.0 フィードを `/feed.xml` で配信します。フィードリーダーでの購読や他サイトとの連携が可能になります。

## 変更点
- App Router の Route Handler (`src/app/feed.xml/route.ts`) で `getBlogPosts()` の全記事を RSS 2.0 として出力
- 各 `<item>` に `title` / `link` / `guid` / `description` / `pubDate`(RFC-822) / `category`(tags) を含む
- XML 特殊文字をエスケープする `escapeXml` ヘルパーを実装（依存追加なし）
- `Content-Type: application/xml; charset=utf-8`
- ブログページと同様 `revalidate = 3600` でキャッシュ

## 動作確認
- `npx tsc --noEmit` でエラーなし
- dev サーバーで `/feed.xml` を取得し、`Content-Type: application/xml` ・XML妥当性・`<item>` 15件を確認

## 備考
- フィード探索用の `<link rel="alternate">` を layout.tsx に追加するのは、別PR(OGP)が同ファイルを編集中のためコンフリクト回避として見送り。必要なら後続で追加可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)