### PR TITLE
feat: add tag filtering to blog

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { MdAccessTime, MdCalendarToday } from "react-icons/md";
 import rehypeHighlight from "rehype-highlight";
 import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
+import Link from "next/link";
 import { Breadcrumb } from "../components/Breadcrumb";
 import { CopyMarkdownButton } from "../components/CopyMarkdownButton";
 import { LikeButton } from "../components/LikeButton";
@@ -192,13 +193,14 @@ export default async function BlogPost({ params }: Props) {
           {post.tags && post.tags.length > 0 && (
             <div className="flex flex-wrap gap-2" role="list" aria-label="Tags">
               {post.tags.map((tag) => (
-                <span
+                <Link
                   key={tag}
-                  className="text-sm bg-blue-100 text-blue-800 px-3 py-1 rounded-full font-medium"
+                  href={`/blog?tag=${tag}`}
+                  className="text-sm bg-blue-100 text-blue-800 px-3 py-1 rounded-full font-medium hover:bg-blue-200 transition-colors"
                   role="listitem"
                 >
                   {tag}
-                </span>
+                </Link>
               ))}
             </div>
           )}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -27,9 +27,7 @@ type Props = {
 
 const Blog = async ({ searchParams }: Props) => {
   const { tag } = await searchParams;
-  const allPosts = getBlogPosts();
-
-  const posts = tag ? allPosts.filter((post) => post.tags?.includes(tag)) : allPosts;
+  const posts = getBlogPosts(tag);
 
   const postsByYear = posts.reduce(
     (acc, post) => {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -21,8 +21,15 @@ export const metadata: Metadata = {
   },
 };
 
-const Blog = () => {
-  const posts = getBlogPosts();
+type Props = {
+  searchParams: Promise<{ tag?: string }>;
+};
+
+const Blog = async ({ searchParams }: Props) => {
+  const { tag } = await searchParams;
+  const allPosts = getBlogPosts();
+
+  const posts = tag ? allPosts.filter((post) => post.tags?.includes(tag)) : allPosts;
 
   const postsByYear = posts.reduce(
     (acc, post) => {
@@ -42,7 +49,7 @@ const Blog = () => {
 
   return (
     <>
-      <PageTitle title="Blog" />
+      <PageTitle title={tag ? `#${tag}` : "Blog"} />
       <div style={{ display: "block", maxWidth: "65ch", marginInlineStart: "auto", marginInlineEnd: "auto" }}>
         {posts.length === 0 ? (
           <p className="text-center text-xl font-semibold">まだ記事がありません。</p>

--- a/src/app/blog/utils/getBlogPosts.ts
+++ b/src/app/blog/utils/getBlogPosts.ts
@@ -7,7 +7,7 @@ const contentDirectory = path.join(process.cwd(), "content/blog");
 
 const SLUG_PATTERN = /^[a-z0-9-]+$/;
 
-export function getBlogPosts(): BlogPostMetadata[] {
+export function getBlogPosts(tag?: string): BlogPostMetadata[] {
   if (!fs.existsSync(contentDirectory)) {
     return [];
   }
@@ -31,8 +31,8 @@ export function getBlogPosts(): BlogPostMetadata[] {
     };
   });
 
-  // sort by date descending
-  return posts.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  const sorted = posts.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  return tag ? sorted.filter((post) => post.tags?.includes(tag)) : sorted;
 }
 
 export function getBlogPost(slug: string): BlogPost | null {


### PR DESCRIPTION
## Summary

- 記事詳細ページのタグをクリックすると `/blog?tag=xxx` へ遷移し、そのタグの記事一覧を表示
- タグ絞り込み時はページタイトルを `#python` 形式で表示
- URL ベースのフィルタリングのためリロード・共有が可能

## Test plan

- [ ] 記事詳細ページのタグをクリック → `/blog?tag=xxx` に遷移することを確認
- [ ] 絞り込み一覧にタグに該当する記事のみ表示されることを確認
- [ ] タイトルが `#タグ名` になることを確認
- [ ] `/blog` では全記事が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)