### PR TITLE
feat: mobile でいいねボタンを表示 / Storybook に mobile viewport を追加

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,29 @@
 import type { Preview } from "@storybook/react";
 import '../src/styles/globals.css';
 
+const customViewports = {
+  mobile1: {
+    name: "Mobile (small)",
+    styles: { width: "320px", height: "568px" },
+    type: "mobile",
+  },
+  mobile2: {
+    name: "Mobile (large)",
+    styles: { width: "414px", height: "896px" },
+    type: "mobile",
+  },
+  tablet: {
+    name: "Tablet",
+    styles: { width: "834px", height: "1112px" },
+    type: "tablet",
+  },
+  desktop: {
+    name: "Desktop",
+    styles: { width: "1280px", height: "800px" },
+    type: "desktop",
+  },
+} as const;
+
 const preview: Preview = {
   parameters: {
     actions: { argTypesRegex: "^on[A-Z].*" },
@@ -9,6 +32,9 @@ const preview: Preview = {
         color: /(background|color)$/i,
         date: /Date$/i,
       },
+    },
+    viewport: {
+      viewports: customViewports,
     },
   },
 };

--- a/src/app/blog/[slug]/BlogPostLayout.tsx
+++ b/src/app/blog/[slug]/BlogPostLayout.tsx
@@ -8,11 +8,12 @@ import { BlogPostContent } from "./BlogPostContent";
 type Props = {
   children: ReactNode;
   header: ReactNode;
+  footer?: ReactNode;
   content: string;
   lang: string;
 };
 
-export function BlogPostLayout({ children, header, content, lang }: Props) {
+export function BlogPostLayout({ children, header, footer, content, lang }: Props) {
   const [translatedContent, setTranslatedContent] = useState<string | null>(null);
 
   return (
@@ -22,6 +23,7 @@ export function BlogPostLayout({ children, header, content, lang }: Props) {
       <article className="min-w-0 text-left" style={{ maxWidth: "40em", width: "100%" }}>
         {header}
         <BlogPostContent translatedContent={translatedContent}>{children}</BlogPostContent>
+        {footer}
       </article>
     </>
   );

--- a/src/app/blog/[slug]/BlogPostPage.stories.tsx
+++ b/src/app/blog/[slug]/BlogPostPage.stories.tsx
@@ -1,0 +1,147 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { MdAccessTime, MdCalendarToday } from "react-icons/md";
+import Link from "next/link";
+import { Breadcrumb } from "../components/Breadcrumb";
+import { CopyMarkdownButton } from "../components/CopyMarkdownButton";
+import { LikeButton } from "../components/LikeButton";
+import { TableOfContents } from "../components/TableOfContents";
+import type { TocItem } from "../utils/extractHeadings";
+import { BlogPostLayout } from "./BlogPostLayout";
+
+const title = "タスクキューで画像リサイズを非同期化する";
+const slug = "blog-post-page-demo";
+const tags = ["Python", "Celery", "Redis"];
+const likeCount = 128;
+
+const markdownContent = [
+  "## はじめに",
+  "画像アップロードのたびにリサイズを同期処理していると、レスポンスが遅くなります。",
+  "## アーキテクチャ",
+  "Celery と Redis を組み合わせてジョブをキューに積み、ワーカーで処理します。",
+  "### ワーカーの構成",
+  "複数ワーカーを起動し、水平にスケールさせます。",
+  "## まとめ",
+  "非同期化でレスポンスタイムを大幅に改善できました。",
+].join("\n\n");
+
+const headings: TocItem[] = [
+  { id: "title", text: title, level: 1 },
+  { id: "はじめに", text: "はじめに", level: 2 },
+  { id: "アーキテクチャ", text: "アーキテクチャ", level: 2 },
+  { id: "ワーカーの構成", text: "ワーカーの構成", level: 3 },
+  { id: "まとめ", text: "まとめ", level: 2 },
+];
+
+const breadcrumbItems = [{ label: "Home", href: "/" }, { label: "Blog", href: "/blog" }, { label: title }];
+
+const header = (
+  <>
+    <Breadcrumb items={breadcrumbItems} />
+
+    <header className="mb-8 mt-4">
+      <h1 id="title" className="text-2xl md:text-3xl font-bold mb-6 leading-tight text-gray-900 scroll-mt-24">
+        {title}
+      </h1>
+
+      <div className="flex flex-wrap items-center gap-4 text-sm text-gray-600 mb-6">
+        <time dateTime="2026-06-15" className="flex items-center gap-2">
+          <MdCalendarToday className="w-4 h-4" aria-hidden="true" />
+          June 15, 2026
+        </time>
+
+        <span className="flex items-center gap-2" aria-label="Reading time: 5 min read">
+          <MdAccessTime className="w-4 h-4" aria-hidden="true" />5 min read
+        </span>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap gap-2" role="list" aria-label="Tags">
+          {tags.map((tag) => (
+            <Link
+              key={tag}
+              href={`/blog?tag=${tag}`}
+              className="text-sm bg-blue-100 text-blue-800 px-3 py-1 rounded-full font-medium hover:bg-blue-200 transition-colors"
+              role="listitem"
+            >
+              {tag}
+            </Link>
+          ))}
+        </div>
+        <CopyMarkdownButton content={markdownContent} />
+      </div>
+    </header>
+  </>
+);
+
+const body = (
+  <>
+    <h2 className="text-3xl font-bold mt-10 mb-5 leading-tight text-gray-900 scroll-mt-24">はじめに</h2>
+    <p className="mb-8 leading-relaxed text-gray-700 text-base md:text-lg" style={{ lineHeight: "1.6" }}>
+      画像アップロードのたびにリサイズを同期処理していると、レスポンスが遅くなります。本記事ではタスクキューで非同期化する方法を解説します。
+    </p>
+    <h2 className="text-3xl font-bold mt-10 mb-5 leading-tight text-gray-900 scroll-mt-24">アーキテクチャ</h2>
+    <p className="mb-8 leading-relaxed text-gray-700 text-base md:text-lg" style={{ lineHeight: "1.6" }}>
+      Celery と Redis を組み合わせてジョブをキューに積み、ワーカーで処理します。リクエストは即座にジョブIDを返します。
+    </p>
+    <h3 className="text-2xl font-bold mt-8 mb-4 leading-tight text-gray-900 scroll-mt-24">ワーカーの構成</h3>
+    <p className="mb-8 leading-relaxed text-gray-700 text-base md:text-lg" style={{ lineHeight: "1.6" }}>
+      複数ワーカーを起動し、負荷に応じて水平にスケールさせます。
+    </p>
+    <h2 className="text-3xl font-bold mt-10 mb-5 leading-tight text-gray-900 scroll-mt-24">まとめ</h2>
+    <p className="mb-8 leading-relaxed text-gray-700 text-base md:text-lg" style={{ lineHeight: "1.6" }}>
+      非同期化でレスポンスタイムを大幅に改善できました。
+    </p>
+  </>
+);
+
+const meta = {
+  title: "Blog/BlogPostPage",
+  parameters: {
+    layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+    },
+  },
+  render: () => (
+    <div className="min-h-screen">
+      <div className="max-w-7xl mx-auto px-4 pt-4 pb-8 flex justify-center gap-5">
+        <BlogPostLayout
+          content={markdownContent}
+          lang="ja"
+          header={header}
+          footer={
+            <div className="xl:hidden mt-12 pt-8 border-t border-gray-200 flex justify-center">
+              <LikeButton slug={slug} initialCount={likeCount} />
+            </div>
+          }
+        >
+          {body}
+        </BlogPostLayout>
+
+        <div className="hidden xl:flex flex-col gap-6 sticky top-24 self-start shrink-0 ml-3">
+          <TableOfContents headings={headings} />
+          <LikeButton slug={slug} initialCount={likeCount} />
+        </div>
+      </div>
+    </div>
+  ),
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: "desktop",
+    },
+  },
+};
+
+export const Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: "mobile1",
+    },
+  },
+};

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -213,7 +213,16 @@ export default async function BlogPost({ params }: Props) {
   return (
     <div className="min-h-screen">
       <div className="max-w-7xl mx-auto px-4 pt-4 pb-8 flex justify-center gap-5">
-        <BlogPostLayout content={post.content} lang={post.lang || "en"} header={headerContent}>
+        <BlogPostLayout
+          content={post.content}
+          lang={post.lang || "en"}
+          header={headerContent}
+          footer={
+            <div className="xl:hidden mt-12 pt-8 border-t border-gray-200 flex justify-center">
+              <LikeButton slug={post.slug} initialCount={likeCount} />
+            </div>
+          }
+        >
           <MDXRemote
             source={post.content}
             components={components}

--- a/src/app/blog/components/LikeButton.stories.tsx
+++ b/src/app/blog/components/LikeButton.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { LikeButton } from "./LikeButton";
+
+const meta = {
+  title: "Blog/LikeButton",
+  component: LikeButton,
+  args: {
+    slug: "storybook-demo",
+    initialCount: 42,
+  },
+} satisfies Meta<typeof LikeButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: "mobile1",
+    },
+  },
+};


### PR DESCRIPTION
## 概要

- **mobile でいいねボタンが表示されない問題を修正**
  - いいねボタンはデスクトップ用サイドバー（`hidden xl:flex`）内にのみ存在し、xl 未満では非表示になっていた
  - mobile（xl 未満）では記事末尾にいいねボタンを表示するようにした（`xl:hidden`）
- **Storybook で mobile size を試せるように**
  - `preview.ts` に viewport（Mobile / Tablet / Desktop）を設定
  - `LikeButton` / `BlogPostPage` の story を追加（Desktop / Mobile variant 付き）

## 実装メモ

- `BlogPostLayout` に `footer` スロットを追加。本文末尾に直接置くと ChromeAI 翻訳時に `children` が差し替わっていいねボタンが消えるため、`BlogPostContent` の外側（`footer`）に置いて翻訳の有無に関わらず常に表示されるようにした。
- デスクトップ（xl 以上）は従来どおりサイドバーのいいねボタンのままで、重複しない。

## 確認

- `pnpm storybook` で `Blog/BlogPostPage` の Desktop / Mobile を切り替え、いいねボタンの出し分けを確認
- biome lint / 型チェック（変更ファイル）パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)