### PR TITLE
fix: モバイルでの横スクロールとブログ一覧の見切れを修正

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -48,7 +48,10 @@ const Blog = async ({ searchParams }: Props) => {
   return (
     <>
       <PageTitle title={tag ? `#${tag}` : "Blog"} />
-      <div style={{ display: "block", maxWidth: "65ch", marginInlineStart: "auto", marginInlineEnd: "auto" }}>
+      <div
+        className="px-4"
+        style={{ display: "block", maxWidth: "65ch", marginInlineStart: "auto", marginInlineEnd: "auto" }}
+      >
         {posts.length === 0 ? (
           <p className="text-center text-xl font-semibold">まだ記事がありません。</p>
         ) : (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+/* モバイルで数pxの横スクロールが出るのを防ぐガード。
+   root（html）に効かせないと viewport レベルのスクロールが残る。
+   clip はスクロールコンテナを作らないので、記事ページの sticky 目次を壊さない。 */
+html,
+body {
+  max-width: 100%;
+  overflow-x: clip;
+}
+
 ::view-transition-old(root),
 ::view-transition-new(root) {
   animation-duration: 300ms;


### PR DESCRIPTION
## 概要
モバイルで発生していた2点のレイアウト不具合を修正します。

- ページ全体で数pxの横スクロールができてしまう
- ブログ一覧の内容が画面端に張り付いて見切れる

## 変更
- `html, body` に `overflow-x: clip` と `max-width: 100%` を追加し、横スクロールを防止
  - `clip` はスクロールコンテナを作らないため、記事ページの sticky 目次を壊しません
- ブログ一覧のラッパーに `px-4` を追加し、端への張り付きを解消

## 確認
- モバイル幅で各ページの横スクロールが消えることを確認
- ブログ一覧に左右の余白が付くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)